### PR TITLE
Remove unused "main" key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "next-mdx-frontmatter",
   "version": "0.0.3",
   "description": "Use MDX + front-matter with Next.js",
-  "main": "n/a",
   "scripts": {
-    "test": "n/a"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm getting this warning when using next-mdx-frontmatter:

```
(node:150) [DEP0128] DeprecationWarning: Invalid 'main' field in '/home/ahupp/ahupp.github.io/node_modules/next-mdx-frontmatter/package.json' of 'n/a'. Please either fix that or report it to the module author
```

Removing this field should fix the issue.